### PR TITLE
Feature/Auto Resizing Notes

### DIFF
--- a/src/components/TextArea.js
+++ b/src/components/TextArea.js
@@ -7,15 +7,21 @@ function TextArea({initValue, onSubmit}){
     const textAreaElm = useRef();
 
     function onKeyDown(e) {
-        calculateHeight();
         if(e.keyCode === 13 && e.shiftKey === false){
             e.preventDefault();
             onSubmit(textInput);
         }
     }
 
+    // This function should return the target height for this element
     function calculateHeight() {
-        console.log(textAreaElm.current.scrollHeight)
+        return textAreaElm.current.scrollHeight;
+    }
+
+    function calculateLines(oneLineHeight, scrollHeight) {
+        const lines = Number.parseInt(scrollHeight / oneLineHeight);
+
+        return lines;
     }
 
     return (

--- a/src/components/TextArea.js
+++ b/src/components/TextArea.js
@@ -2,7 +2,6 @@ import {React, useState, useEffect, useRef} from "react"
 
 function TextArea({initValue, onSubmit}){
     const [textInput, setTextInput] = useState("");
-    const [lines, setLines] = useState(2);
     useEffect(()=>{setTextInput(initValue)},[initValue]);
 
     const textAreaElm = useRef();
@@ -14,28 +13,23 @@ function TextArea({initValue, onSubmit}){
         }
     }
 
-    function onKeyUp(e) {
-        // TODO: Get this value dinamicaly by checking the size of this element with a single line
-        setLines(calculateLines(15, calculateHeight()));
-    }
-
     // This function should return the target height for this element
-    function calculateHeight() {
-        // TODO: Get this value from a not resized textarea, to get the real scrollHeight (auto shrink)
-        return textAreaElm.current.scrollHeight;
+    function calculateHeight(textAreaElement) {
+        return textAreaElement.scrollHeight;
     }
 
-    function calculateLines(oneLineHeight, scrollHeight) {
-        const lines = Number.parseInt(scrollHeight / oneLineHeight);
-
-        return lines;
-    }
+    useEffect(() => {
+        textAreaElm.current.style.height=0;
+        const newHeight = calculateHeight(textAreaElm.current,2);
+        textAreaElm.current.style.height= newHeight+"px";
+    },[textInput])
 
     return (
         <form>
             <textarea ref={textAreaElm} onChange={(e) => setTextInput(e.target.value)} value={textInput} 
-            rows={lines}
-            onKeyDown={onKeyDown} onKeyUp={onKeyUp} style={{resize:"none"}}/>
+            onKeyDown={onKeyDown} 
+            rows="1"
+            style={{resize:"none"}}/>
             <input type="submit" hidden/>
         </form>
     )

--- a/src/components/TextArea.js
+++ b/src/components/TextArea.js
@@ -1,19 +1,26 @@
-import {React, useState, useEffect} from "react"
+import {React, useState, useEffect, useRef} from "react"
 
 function TextArea({initValue, onSubmit}){
     const [textInput, setTextInput] = useState("");
     useEffect(()=>{setTextInput(initValue)},[initValue]);
 
+    const textAreaElm = useRef();
+
     function onKeyDown(e) {
-        if(e.keyCode == 13 && e.shiftKey == false){
+        calculateHeight();
+        if(e.keyCode === 13 && e.shiftKey === false){
             e.preventDefault();
             onSubmit(textInput);
         }
     }
 
+    function calculateHeight() {
+        console.log(textAreaElm.current.scrollHeight)
+    }
+
     return (
         <form>
-            <textarea onChange={(e) => setTextInput(e.target.value)} value={textInput} onKeyDown={onKeyDown}style={{resize:"none"}}/>
+            <textarea ref={textAreaElm} onChange={(e) => setTextInput(e.target.value)} value={textInput} onKeyDown={onKeyDown}style={{resize:"none"}}/>
             <input type="submit" hidden/>
         </form>
     )

--- a/src/components/TextArea.js
+++ b/src/components/TextArea.js
@@ -2,6 +2,7 @@ import {React, useState, useEffect, useRef} from "react"
 
 function TextArea({initValue, onSubmit}){
     const [textInput, setTextInput] = useState("");
+    const [lines, setLines] = useState(2);
     useEffect(()=>{setTextInput(initValue)},[initValue]);
 
     const textAreaElm = useRef();
@@ -13,8 +14,14 @@ function TextArea({initValue, onSubmit}){
         }
     }
 
+    function onKeyUp(e) {
+        // TODO: Get this value dinamicaly by checking the size of this element with a single line
+        setLines(calculateLines(15, calculateHeight()));
+    }
+
     // This function should return the target height for this element
     function calculateHeight() {
+        // TODO: Get this value from a not resized textarea, to get the real scrollHeight (auto shrink)
         return textAreaElm.current.scrollHeight;
     }
 
@@ -26,7 +33,9 @@ function TextArea({initValue, onSubmit}){
 
     return (
         <form>
-            <textarea ref={textAreaElm} onChange={(e) => setTextInput(e.target.value)} value={textInput} onKeyDown={onKeyDown}style={{resize:"none"}}/>
+            <textarea ref={textAreaElm} onChange={(e) => setTextInput(e.target.value)} value={textInput} 
+            rows={lines}
+            onKeyDown={onKeyDown} onKeyUp={onKeyUp} style={{resize:"none"}}/>
             <input type="submit" hidden/>
         </form>
     )


### PR DESCRIPTION
Resize the TextArea inside a note based on it's value (The text inside it). Get the height of the scroll when the textarea height is 0 and use the value as the new height of the textarea.

This process is done inside a useEffect, and manipulate a DOM ref directly, since with the shadow DOM it either updated all at once so we couldnt get the true scrollHeight before updating or it would create a bug with the auto shrinking because (i think) it would only do the check once it needed to re-render because of the scroll appearing.

But keep an eye for bugs in the DOM.