### PR TITLE
Added fetch with POST with new note data

### DIFF
--- a/src/utils/CustomHooks/useNotes.js
+++ b/src/utils/CustomHooks/useNotes.js
@@ -73,11 +73,47 @@ function useNoteList() {
         }).finally(() => {
             setConnection({successful:connectSuccess, lastOperation:getNotes});
         })
-
+        
     }
     
     function addNote(text) {
         const lnid = getLastNoteId(ls)+1;
+        
+        const data_path = "/api/add"
+        const url = source_url + data_path
+        let connectSuccess = false;
+        fetch(url,{
+            method: "POST",
+            mode: "cors",
+            credentials: "same-origin",
+            headers: {
+                "Content-Type":"application/json"
+            },
+            body: JSON.stringify({"id":lnid, "text":text})
+        })
+         .then(response => {
+            if(response.ok){
+                connectSuccess = true; 
+                return response.text()
+            }
+            else {
+                if (response.status === "NO_RESPONSE_CODE") {
+                    // No server
+                    console.log("Failed connection to server")
+                    return Promise.reject(new Error("Server Unavailable"))
+                }
+            }
+        })
+        .then(r => {
+            console.log(r)
+        })
+        .catch(error => {
+            console.log(error.toString())
+            console.log("Was not able to connect to server")
+        }).finally(() => {
+            setConnection({successful:connectSuccess, lastOperation: () => addNote(text)});
+        })
+
         setLs([...ls, createNote(lnid, text)]);
     }
 


### PR DESCRIPTION
Added fetch from Javascript Fetch API in the addNote function to send a post request to the API with data of the new note.

- The POST sends the new note data in the body as JSON
- It checks if the response was ok, meaning that connection to the API was made
- Treats any error
- Set the connection state with an anonymous version of it's call as the lastOperation. 