### PR TITLE
Added fetch with POST to deleteNote with id to be deleted

### DIFF
--- a/src/utils/CustomHooks/useNotes.js
+++ b/src/utils/CustomHooks/useNotes.js
@@ -37,7 +37,7 @@ function getLastNoteId(notes) {
 
 function useNoteList() {
     const [ls, setLs] = useState([]);
-    const [connection,setConnection] = useState({successful: false, lastOperation: null});
+    const [connection,setConnection] = useState({successful: false, lastOperation: getNotes});
 
     // Load data
     useEffect(() => {getNotes()},[])
@@ -82,6 +82,32 @@ function useNoteList() {
     }
 
     function deleteNote(id) {
+        const remove_path = "/api/delete"
+        const url = source_url + remove_path
+        let connectSuccess = false;
+        fetch(url, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json; charset=utf-8"
+            },
+            body: JSON.stringify({"id":id}),
+        }).then(response => {
+            if(response.ok){
+                connectSuccess = true;
+               return response.text(); 
+            }else{
+                console.log(response.status)
+            }
+        }).then(r => {
+            if(Number.parseInt(r) === 1) {
+                console.log("Sucess deleting " + r + " note with noteId " + id)                
+            }else{
+                console.log("Error during operation. Exactly " + r + " notes were deleted.")
+                console.log("NoteId: " + id)
+            }
+        }).catch(err => console.log(err))
+        .finally(() => {setConnection({successful:connectSuccess, lastOperation:() => deleteNote(id)});})
+        
         setLs(ls.filter((n) => n.id !== id));
     }
 


### PR DESCRIPTION
Added fetch from Javascript Fetch API in the deleteNote function to send a post request to the API with data of the note to be deleted.

- The POST sends the id of the note to be deleted in the body as JSON
- It checks if the response was ok, meaning that connection to the API was made
- Checks if one, and only one note was deleted.
- Treats any errors with catch
- Set the connection state with an anonymous version of it's call as the lastOperation.