### PR TITLE
Bugfix/Notes Order Problem 

### DIFF
--- a/src/utils/CustomHooks/useNotes.js
+++ b/src/utils/CustomHooks/useNotes.js
@@ -88,8 +88,7 @@ function useNoteList() {
                 const [isnote, err] = isNote(d);
                 if (!isnote) return Promise.reject(new Error(err));    
             }
-            const sortedData = orderNoteList(data);
-            setLs(sortedData);
+            setLs(removeGapFromList(data));
         })
             .catch(error => {
                 console.log(error.toString())
@@ -131,7 +130,7 @@ function useNoteList() {
             setConnection({successful:connectSuccess, lastOperation: () => addNote(text)});
         })
 
-        setLs([...ls, createNote(lnid, text, lorder)]);
+        setLs(removeGapFromList([...ls, createNote(lnid, text, lorder)]));
     }
     
     function deleteNote(id) {
@@ -153,7 +152,7 @@ function useNoteList() {
         }).then().catch(err => console.log(err))
         .finally(() => {setConnection({successful:connectSuccess, lastOperation:() => deleteNote(id)});})
         
-        setLs(ls.filter((n) => n.id !== id));
+        setLs(removeGapFromList(ls.filter((n) => n.id !== id)));
     }
     
     function editNote(noteData) {
@@ -193,7 +192,7 @@ function useNoteList() {
             if (n.id === noteData.id) return editedNote
             return n;
         });
-        setLs(newList);        
+        setLs(removeGapFromList(newList));        
     }
     
     function switchNoteOrder(noteOrdA, noteOrdB) {
@@ -240,7 +239,7 @@ function useNoteList() {
             }
             return n;
         })
-        setLs(newData);
+        setLs(removeGapFromList(newData));
     }
     
     return [ls,  addNote, deleteNote, editNote, connection, switchNoteOrder]

--- a/src/utils/CustomHooks/useNotes.js
+++ b/src/utils/CustomHooks/useNotes.js
@@ -43,12 +43,16 @@ function getLastNoteId(notes) {
     return lnid;
 }
 
+function orderNoteList(noteList) {
+    return [...noteList].sort((a,b) => a.order - b.order);
+}
+
 function removeGapFromList(notes){
     let lastOrder = 0;
-    return notes.sort((n1, n2) => n1.order - n2.order).map((n) => {
+    return orderNoteList(notes).map((n) => {
         let toReturn = n;
-        if (n.order > lastOrder+1) {
-            toReturn = {...n, order:lastOrder+1}
+        if (n.order > lastOrder) {
+            toReturn = {...n, order:lastOrder}
         }
         lastOrder+=1;
         return toReturn;
@@ -61,10 +65,6 @@ function useNoteList() {
 
     // Load data
     useEffect(() => {getNotes()}, [])
-
-    function orderNoteList(noteList) {
-        return [...noteList].sort((a,b) => a.order - b.order);
-    }
 
     function getNotes() {
         const data_path = "/api/notes"

--- a/src/utils/CustomHooks/useNotes.js
+++ b/src/utils/CustomHooks/useNotes.js
@@ -43,6 +43,18 @@ function getLastNoteId(notes) {
     return lnid;
 }
 
+function removeGapFromList(notes){
+    let lastOrder = 0;
+    return notes.sort((n1, n2) => n1.order - n2.order).map((n) => {
+        let toReturn = n;
+        if (n.order > lastOrder+1) {
+            toReturn = {...n, order:lastOrder+1}
+        }
+        lastOrder+=1;
+        return toReturn;
+    })
+}
+
 function useNoteList() {
     const [ls, setLs] = useState([]);
     const [connection, setConnection] = useState({successful: false, lastOperation: getNotes});


### PR DESCRIPTION
Closes #28 
Fixes the problem with gaps by checking in every operation the whole list and updating the values whenever a gap is found.
Notes never have duplicated order this way because it checks if the first note is bigger than 0, and then updates all the rest based on this.

Future problems to consider:
- This updates the front end, but not the server. Data still comes with duplicated and gapping orders, so this should probably be implemented as a business rule in the server, not only in the front end. Or pass the whole list as a object to be saved in the database on each change