### PR TITLE
fixed the new note transparent button to white color

### DIFF
--- a/src/components/Containers/CircleContainer.css
+++ b/src/components/Containers/CircleContainer.css
@@ -1,4 +1,5 @@
 .circle-container {
     border: solid black 1px;
     border-radius: 100%;
+    background-color: white;
 }


### PR DESCRIPTION
fix : fixed the transparent button to white #26
![image](https://github.com/PorthoGamesBR/my-notes/assets/49724360/b0817a97-062d-4dd0-b48a-a1be4e6b962c)
